### PR TITLE
Added QuickFill draw strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,13 @@ go bot directory
 * [optional] **--draw_strategy**            draw strategy default by: *randomize* Avaiable strategy list : 
 
     * *linear* :    line by line paint, 
-    
+
+    * *qf* :        Quickfill line by line. Will draw a 3x3 square in this order:
+
+            | 1 | 6 | 2 |
+            | 7 | 3 | 8 |
+            | 4 | 9 | 5 |
+
     * *randomize* : pixel paint random coordinates, 
     
     * *status* :    not painted only list paint status --support colors ignored parameters, don't suppurt sketch mode--

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -69,6 +69,28 @@ class Linear(Strategy):
                     self.bot.start_y + y) not in self.colors_not_overwrite:
                     self.bot.paint(self.bot.start_x + x, self.bot.start_y + y, color)
 
+class QuickFill(Strategy):
+    def __init__(self, bot, colors_ignored, colors_not_overwrite):
+        self.bot = bot
+        self.colors_ignored = colors_ignored
+
+        self.colors_not_overwrite = colors_not_overwrite
+
+        self.b = True
+
+    def apply(self):
+        for y in xrange(self.bot.image.height):
+            for x in xrange(self.bot.image.width):
+                color = EnumColor.rgb(self.bot.image.pix[x, y], True)
+                if self.bot.canvas.get_color(self.bot.start_x + x,
+                                             self.bot.start_y + y) != color and not color in self.colors_ignored and self.bot.canvas.get_color(
+                    self.bot.start_x + x,
+                    self.bot.start_y + y) not in self.colors_not_overwrite:
+                    if (x % 2 == self.b):
+                        self.bot.paint(self.bot.start_x + x, self.bot.start_y + y, color)
+            self.b = not self.b
+        self.b = False
+
 
 class Sketch(Strategy):
     def __init__(self, bot, colors_ignored, colors_not_overwrite):
@@ -581,6 +603,9 @@ class FactoryStrategy(object):
 
         if strategy == 'linear':
             return Linear(bot, colors_ignored, colors_not_overwrite)
+
+        if strategy == 'qf':
+            return QuickFill(bot, colors_ignored, colors_not_overwrite)
 
         if strategy == 'status':
             return Status(bot, colors_ignored, colors_not_overwrite)


### PR DESCRIPTION
QuickFill wors like linear mode but starts by only filling every other pixel. A 3x3 square will be painted in the following order:
| 1 | 6 | 2 |
| 7 | 3 | 8 |
| 4 | 9 | 5 |
