### PR TITLE
Add error message for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,15 @@ except ImportError, e:
 
 print "Checking required packages"
 pkgs = ['websocket-client', 'Pillow', 'requests', 'pyqrcode', 'pypng', 'six']
-for package in pkgs:
-    try:
-        import package
-    except ImportError, e:
-        pip.main(['install', package])
+try:
+    for package in pkgs:
+        try:
+            import package
+        except ImportError, e:
+                pip.main(['install', package])
 
-print "OK"
+    print "OK"
+except AttributeError, e:
+    print("It seems you pip version is over 10.0, please install the required packages manually, "
+          "by executing following command:\n"
+          "pip install websocket-client Pillow requests pyqrcode pypng six")


### PR DESCRIPTION
pip removed ```pip.main()``` in the version 10.0, therefore you need to manually install the required packages. 

If you run ```python setup.py``` it would result in:
```bash
Traceback (most recent call last):
  File "setup.py", line 18, in <module>
    pip.main(['install', package])
AttributeError: 'module' object has no attribute 'main'
```