### PR TITLE
Changes for python 3 compatiblity

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,9 +87,13 @@ def main():
         try:
             bot.run()
         except NeedUserInteraction as exception:
-            alert(exception.message)
-            if raw_input(I18n.get('token_resolved')) == 'y':
-                run()
+            alert(str(exception))
+            try:
+                if raw_input(I18n.get('token_resolved')).strip() == 'y':
+                    run()
+            except NameError as e:
+                if input(I18n.get('token_resolved')).strip() == 'y':
+                    run()
 
     run()
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 try:
     import pip
-except ImportError, e:
+except ImportError as e:
     print "installing pip"
     os.system("get-pip.py")
     import pip
@@ -14,7 +14,7 @@ pkgs = ['websocket-client', 'Pillow', 'requests', 'pyqrcode', 'pypng', 'six']
 for package in pkgs:
     try:
         import package
-    except ImportError, e:
+    except ImportError as e:
         pip.main(['install', package])
 
 print "OK"


### PR DESCRIPTION
When using python 3.6.6 i found some errors, the PR #79 wasn't tested enough.

In python 3.6.6 there was no attribute message on the exception object and in both versions the object is already the desired message, so there is no need to do ```exception.message```.

```raw_input()``` has also been renamed to ```input()``` in python 3, but it also exists in python 2 and it is equivalent to ```eval(input())``` which is not secure, so we only use ```input()``` when ```raw_input()```  doesn't exists.

Excepting errors but not using ```as``` to define the error variable doesn't work in python 3